### PR TITLE
Fix bug in workflow retriever

### DIFF
--- a/multi_x_serverless/data_collector/components/workflow/workflow_retriever.py
+++ b/multi_x_serverless/data_collector/components/workflow/workflow_retriever.py
@@ -146,7 +146,9 @@ class WorkflowRetriever(DataRetriever):
                     all_transfer_sizes = set()
                     # Aggregate all sizes and latencies
                     for transfer_information in to_regions.values():
-                        all_transfer_sizes.update([float(data) for data in transfer_information["transfer_size_to_transfer_latencies"].keys()])
+                        all_transfer_sizes.update(
+                            [float(data) for data in transfer_information["transfer_size_to_transfer_latencies"].keys()]
+                        )
 
                     # Calculate global averages for each size
                     global_avg_latency_per_size = {}

--- a/multi_x_serverless/tests/data_collector/components/workflow/test_workflow_retriever.py
+++ b/multi_x_serverless/tests/data_collector/components/workflow/test_workflow_retriever.py
@@ -117,7 +117,7 @@ class TestWorkflowRetriever(unittest.TestCase):
         # Set up the test data
         instance_summary = {}
         log = {
-            "execution_latencies": {"instance1": {"provider_region": "provider1:region1", "latency": "0.1"}},
+            "execution_latencies": {"instance1": {"provider_region": "provider1:region1", "latency": 0.1}},
             "start_hop_destination": {"provider": "provider1", "region": "region1"},
             "transmission_data": [
                 {
@@ -132,6 +132,7 @@ class TestWorkflowRetriever(unittest.TestCase):
             "non_executions": {"instance1": {"instance2": 1}},
         }
 
+        self.workflow_retriever._handle_missing_region_to_region_transmission_data = Mock()
         # Call the method
         self.workflow_retriever._extend_instance_summary(instance_summary, log)
 
@@ -139,7 +140,7 @@ class TestWorkflowRetriever(unittest.TestCase):
         expected_result = {
             "instance1": {
                 "invocations": 1,
-                "executions": {"provider1:region1": ["0.1"]},
+                "executions": {"provider1:region1": [0.1]},
                 "to_instance": {
                     "instance2": {
                         "invoked": 0,


### PR DESCRIPTION
Tiny bug that generates a whole lot of problems by exploding the problem size unnecessarily.