### PR TITLE
Activate the auto timeout for remote CLI Manage Deployments

### DIFF
--- a/caribou/deployment/client/remote_cli/remote_cli_handler.py
+++ b/caribou/deployment/client/remote_cli/remote_cli_handler.py
@@ -144,5 +144,5 @@ def handle_run(event: dict[str, Any]) -> dict[str, Any]:
 
 
 def handle_default(event: dict[str, Any]) -> dict[str, Any]:  # pylint: disable=unused-argument
-    print("Unknown action")
+    logger.error("Unknown action")
     return {"status": 400, "message": "Unknown action"}

--- a/caribou/deployment/client/remote_cli/remote_cli_handler.py
+++ b/caribou/deployment/client/remote_cli/remote_cli_handler.py
@@ -67,7 +67,9 @@ def handle_manage_deployments(event: dict[str, Any]) -> dict[str, Any]:
             "message": "Invalid deployment_metrics_calculator_type specified. Allowed values are 'simple', 'go'",
         }
 
-    deployment_manager = DeploymentManager(deployment_metrics_calculator_type)
+    # Declare the deployment manager with parameter of lambda_timeout=True (This
+    # sets an early termination for the deployment manager to avoid lambda timeout)
+    deployment_manager = DeploymentManager(deployment_metrics_calculator_type, lambda_timeout=True)
     deployment_manager.check()
     return {
         "status": 200,

--- a/caribou/deployment_solver/deployment_algorithms/deployment_algorithm.py
+++ b/caribou/deployment_solver/deployment_algorithms/deployment_algorithm.py
@@ -88,6 +88,8 @@ class DeploymentAlgorithm(ABC):  # pylint: disable=too-many-instance-attributes
         ]
 
         self._timeout = AWS_TIMEOUT_SECONDS if lambda_timeout else float("inf")
+        if lambda_timeout:
+            print(f"Remote Deployment: Setting timeout to {AWS_TIMEOUT_SECONDS} seconds")
 
     def run(self, hours_to_run: Optional[list[str]] = None) -> None:
         hour_to_run_to_result: dict[str, Any] = {"time_keys_to_staging_area_data": {}, "deployment_metrics": {}}

--- a/caribou/endpoint/client.py
+++ b/caribou/endpoint/client.py
@@ -29,10 +29,6 @@ from caribou.common.models.remote_client.remote_client_factory import RemoteClie
 # May in the future want to make it just targetting the specific logger
 logging.getLogger("botocore").setLevel(logging.WARNING)
 
-logger = logging.getLogger(__name__)
-logger.setLevel(logging.INFO)
-logger.addHandler(logging.StreamHandler())
-
 
 class Client:
     def __init__(self, workflow_id: Optional[str] = None) -> None:

--- a/caribou/monitors/deployment_manager.py
+++ b/caribou/monitors/deployment_manager.py
@@ -1,5 +1,7 @@
 import json
+import logging
 import math
+import os
 from datetime import datetime, timedelta
 from typing import Optional
 
@@ -38,6 +40,15 @@ from caribou.deployment_solver.deployment_algorithms.stochastic_heuristic_deploy
 from caribou.deployment_solver.workflow_config import WorkflowConfig
 from caribou.monitors.monitor import Monitor
 
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.INFO)
+
+# Only add a StreamHandler if not running in AWS Lambda
+if "AWS_LAMBDA_FUNCTION_NAME" not in os.environ:
+    if not logger.handlers:
+        logger.addHandler(logging.StreamHandler())
+
+
 deployment_algorithm_mapping = {
     "coarse_grained_deployment_algorithm": CoarseGrainedDeploymentAlgorithm,
     "fine_grained_deployment_algorithm": FineGrainedDeploymentAlgorithm,
@@ -53,13 +64,13 @@ class DeploymentManager(Monitor):
         self._lambda_timeout: bool = lambda_timeout
 
     def check(self) -> None:
-        print(f"Running Deployment Manager: Manage Deployments")
+        logger.info("Running Deployment Manager: Manage Deployments")
         deployment_manager_client = self._endpoints.get_deployment_manager_client()
         workflow_ids = deployment_manager_client.get_keys(DEPLOYMENT_MANAGER_RESOURCE_TABLE)
         data_collector_client = self._endpoints.get_data_collector_client()
 
         for workflow_id in workflow_ids:
-            print(f"\nChecking workflow: {workflow_id}")
+            logger.info(f"Checking workflow: {workflow_id}")
             workflow_info_raw, _ = deployment_manager_client.get_value_from_table(
                 DEPLOYMENT_MANAGER_WORKFLOW_INFO_TABLE, workflow_id
             )
@@ -71,7 +82,7 @@ class DeploymentManager(Monitor):
                 current_time = datetime.now(GLOBAL_TIME_ZONE)
                 next_check = datetime.strptime(workflow_info["next_check"], TIME_FORMAT)
                 if current_time < next_check:
-                    print("Not enough time has passed since the last check")
+                    logger.info("Not enough time has passed since the last check")
                     continue
 
             self.workflow_collector.run_on_workflow(workflow_id)
@@ -102,7 +113,7 @@ class DeploymentManager(Monitor):
             # The solver has never been run before for this workflow, and the workflow has not been invoked enough
             # collect more data and wait
             if total_invocation_counts_since_last_solved < MINIMAL_SOLVE_THRESHOLD and workflow_info is None:
-                print("Not enough invocations to run the solver")
+                logger.info("Not enough invocations to run the solver")
                 continue
 
             # Income token
@@ -119,7 +130,7 @@ class DeploymentManager(Monitor):
             )
 
             if not affordable_deployment_algorithm_run:
-                print("Not enough tokens to run the solver")
+                logger.info("Not enough tokens to run the solver")
                 carbon_cost = self._get_cost(len(workflow_config.instances))
                 self._update_workflow_info(
                     carbon_cost - positive_carbon_savings_token - carbon_budget_overflow_last_solved, workflow_id
@@ -131,7 +142,7 @@ class DeploymentManager(Monitor):
             )
 
             solve_hours = self._get_solve_hours(affordable_deployment_algorithm_run["number_of_solves"])
-            print(f"Running deployment algorithm with solve hours: {solve_hours}")
+            logger.info(f"Running deployment algorithm with solve hours: {solve_hours}")
             self._run_deployment_algorithm(workflow_config, solve_hours, expiry_delta_seconds)
 
     def _update_workflow_info(self, token_missing: int, workflow_id: str) -> None:
@@ -170,7 +181,7 @@ class DeploymentManager(Monitor):
     ) -> None:
         deployment_algorithm_class = deployment_algorithm_mapping.get(workflow_config.deployment_algorithm)
         if deployment_algorithm_class:
-            print(f"Running deployment algorithm: {workflow_config.deployment_algorithm}")
+            logger.info(f"Running deployment algorithm: {workflow_config.deployment_algorithm}")
             deployment_algorithm: DeploymentAlgorithm = deployment_algorithm_class(workflow_config, expiry_delta_seconds, deployment_metrics_calculator_type=self._deployment_metrics_calculator_type, lambda_timeout=self._lambda_timeout)  # type: ignore
             deployment_algorithm.run(solve_hours)
         else:

--- a/caribou/monitors/deployment_manager.py
+++ b/caribou/monitors/deployment_manager.py
@@ -46,10 +46,11 @@ deployment_algorithm_mapping = {
 
 
 class DeploymentManager(Monitor):
-    def __init__(self, deployment_metrics_calculator_type: str = "simple") -> None:
+    def __init__(self, deployment_metrics_calculator_type: str = "simple", lambda_timeout: bool = False) -> None:
         super().__init__()
         self.workflow_collector = WorkflowCollector()
         self._deployment_metrics_calculator_type: str = deployment_metrics_calculator_type
+        self._lambda_timeout: bool = lambda_timeout
 
     def check(self) -> None:
         deployment_manager_client = self._endpoints.get_deployment_manager_client()
@@ -163,7 +164,7 @@ class DeploymentManager(Monitor):
     ) -> None:
         deployment_algorithm_class = deployment_algorithm_mapping.get(workflow_config.deployment_algorithm)
         if deployment_algorithm_class:
-            deployment_algorithm: DeploymentAlgorithm = deployment_algorithm_class(workflow_config, expiry_delta_seconds, deployment_metrics_calculator_type=self._deployment_metrics_calculator_type)  # type: ignore
+            deployment_algorithm: DeploymentAlgorithm = deployment_algorithm_class(workflow_config, expiry_delta_seconds, deployment_metrics_calculator_type=self._deployment_metrics_calculator_type, lambda_timeout=self._lambda_timeout)  # type: ignore
             deployment_algorithm.run(solve_hours)
         else:
             raise ValueError("Invalid deployment algorithm")


### PR DESCRIPTION
Addresses the following issues: 
- [x] closes #327
- [x] Print to console some overview of actions for managing deployments. 

Note: This is a very basic implementation (works well if managing deployments for one workflow); a more comprehensive approach is required to be implemented as a part of issue #304.