### PR TITLE
Update AWS url for coordinates collection

### DIFF
--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -44,6 +44,8 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ !github.event.pull_request.draft }}
     timeout-minutes: 5
+    permissions:
+      pull-requests: write
     steps:
       - uses: actions/checkout@v2
       - name: Setup poetry

--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -56,6 +56,7 @@ jobs:
           poetry run pytest --cache-clear --cov=caribou/ --cov-fail-under=80
           poetry run pytest --junitxml=pytest.xml --cov-report=term-missing:skip-covered --cov-fail-under=80 --cov=caribou caribou/tests | tee pytest-coverage.txt
       - name: Pytest coverage comment
+        if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
         uses: MishaKav/pytest-coverage-comment@main
         with:
           pytest-coverage-path: ./pytest-coverage.txt

--- a/caribou/data_collector/components/provider/provider_retriever.py
+++ b/caribou/data_collector/components/provider/provider_retriever.py
@@ -107,7 +107,6 @@ class ProviderRetriever(DataRetriever):
                 continue
 
             coordinates = self.retrieve_location(region_name)
-            print(f"Coordinates for {region_name}: {coordinates}")
             regions[f"{Provider.AWS.value}:{region_code}"] = {
                 "name": region_name,
                 "provider": Provider.AWS.value,

--- a/caribou/data_collector/components/provider/provider_retriever.py
+++ b/caribou/data_collector/components/provider/provider_retriever.py
@@ -98,7 +98,7 @@ class ProviderRetriever(DataRetriever):
             table_cells = table_row.find_all("td")
             if len(table_cells) < 2:  # We only need first two columns (Code and Name)
                 continue
-            
+
             region_code = table_cells[0].text.strip()
             region_name = table_cells[1].text.strip()
 

--- a/caribou/data_collector/utils/constants.py
+++ b/caribou/data_collector/utils/constants.py
@@ -1,2 +1,2 @@
-AMAZON_REGION_URL = "https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-regions-availability-zones.html#concepts-available-regions"  # pylint: disable=line-too-long
+AMAZON_REGION_URL = "https://docs.aws.amazon.com/global-infrastructure/latest/regions/aws-regions.html#available-regions"  # pylint: disable=line-too-long
 CLOUD_PING = "https://www.cloudping.co/grid/"


### PR DESCRIPTION
This PR updates the retrieve_aws_regions function to reflect recent changes to the AWS regions documentation page. The original logic assumed a specific table structure which has since changed.

Changes
- Updated the source URL to the new AWS regions table:
https://docs.aws.amazon.com/global-infrastructure/latest/regions/aws-regions.html#available-regions

- Adjusted parsing logic




Daniel:
- Also updated Github workflow to skip pytest comments for forked PR merges to avoid test failures. 