### PR TITLE
Refactor deploying image logic

### DIFF
--- a/caribou/common/models/remote_client/aws_remote_client.py
+++ b/caribou/common/models/remote_client/aws_remote_client.py
@@ -405,7 +405,12 @@ class AWSRemoteClient(RemoteClient):  # pylint: disable=too-many-public-methods
             return item["value"]["S"]
         return ""
 
-    def _generate_dockerfile(self, runtime: str, handler: str, additional_docker_commands: Optional[list[str]]) -> str:
+    def _generate_dockerfile(
+        self,
+        runtime: str,
+        handler: str,  # pylint: disable=unused-argument
+        additional_docker_commands: Optional[list[str]],
+    ) -> str:
         run_command = ""
         if additional_docker_commands and len(additional_docker_commands) > 0:
             run_command += " && ".join(additional_docker_commands)

--- a/caribou/common/models/remote_client/aws_remote_client.py
+++ b/caribou/common/models/remote_client/aws_remote_client.py
@@ -256,7 +256,7 @@ class AWSRemoteClient(RemoteClient):  # pylint: disable=too-many-public-methods
     ) -> str:
         workflow_instance_id = "-".join(function_name.split("-")[0:2])
         deployed_image_uri = self._get_deployed_image_uri(function_name)
-        
+
         if len(deployed_image_uri) > 0:
             # If image exists, just copy it to the current region
             image_uri = self._copy_image_if_not_exists(deployed_image_uri)

--- a/caribou/common/models/remote_client/aws_remote_client.py
+++ b/caribou/common/models/remote_client/aws_remote_client.py
@@ -254,9 +254,12 @@ class AWSRemoteClient(RemoteClient):  # pylint: disable=too-many-public-methods
         memory_size: int,
         additional_docker_commands: Optional[list[str]] = None,
     ) -> str:
+        workflow_instance_id = "-".join(function_name.split("-")[0:2])
         deployed_image_uri = self._get_deployed_image_uri(function_name)
+        
         if len(deployed_image_uri) > 0:
-            image_uri = self._copy_image_to_region(deployed_image_uri)
+            # If image exists, just copy it to the current region
+            image_uri = self._copy_image_if_not_exists(deployed_image_uri)
         else:
             if zip_contents is None:
                 raise RuntimeError("No deployed image AND No deployment package provided for function creation")
@@ -275,7 +278,7 @@ class AWSRemoteClient(RemoteClient):  # pylint: disable=too-many-public-methods
                     f_dockerfile.write(dockerfile_content)
 
                 # Step 3: Build the Docker Image
-                image_name = f"{function_name.lower()}:latest"
+                image_name = f"{workflow_instance_id.lower()}:latest"
                 self._build_docker_image(tmpdirname, image_name)
 
                 # Step 4: Upload the Image to ECR
@@ -299,13 +302,16 @@ class AWSRemoteClient(RemoteClient):  # pylint: disable=too-many-public-methods
 
         return arn
 
-    def _copy_image_to_region(self, deployed_image_uri: str) -> str:
+    def _copy_image_if_not_exists(self, deployed_image_uri: str) -> str:
         parts = deployed_image_uri.split("/")
         original_region = parts[0].split(".")[3]
         original_image_name = parts[1]
 
         ecr_client = self._client("ecr")
         new_region = ecr_client.meta.region_name
+        if new_region == original_region:
+            logger.info("Image already exists in the %s region, skipping copy", new_region)
+            return deployed_image_uri
         new_image_name = original_image_name.replace(original_region, new_region)
 
         # Assume AWS CLI is configured. Customize these commands based on your AWS setup.
@@ -369,40 +375,19 @@ class AWSRemoteClient(RemoteClient):  # pylint: disable=too-many-public-methods
 
     def _store_deployed_image_uri(self, function_name: str, image_name: str) -> None:
         workflow_instance_id = "-".join(function_name.split("-")[0:2])
-
-        function_name_simple = function_name[len(workflow_instance_id) + 1 :].rsplit("_", 1)[0]
-
-        if workflow_instance_id not in self._workflow_image_cache:
-            self._workflow_image_cache[workflow_instance_id] = {}
-
-        self._workflow_image_cache[workflow_instance_id].update({function_name_simple: image_name})
-
         client = self._session.client("dynamodb", region_name=GLOBAL_SYSTEM_REGION)
 
-        # Check if the item exists and create dictionary if not
+        # Store the image URI under the workflow ID
         client.update_item(
             TableName=CARIBOU_WORKFLOW_IMAGES_TABLE,
             Key={"key": {"S": workflow_instance_id}},
-            UpdateExpression="SET #v = if_not_exists(#v, :empty_map)",
+            UpdateExpression="SET #v = :value",
             ExpressionAttributeNames={"#v": "value"},
-            ExpressionAttributeValues={":empty_map": {"M": {}}},
-        )
-
-        client.update_item(
-            TableName=CARIBOU_WORKFLOW_IMAGES_TABLE,
-            Key={"key": {"S": workflow_instance_id}},
-            UpdateExpression="SET #v.#f = :value",
-            ExpressionAttributeNames={"#v": "value", "#f": function_name_simple},
             ExpressionAttributeValues={":value": {"S": image_name}},
         )
 
     def _get_deployed_image_uri(self, function_name: str, consistent_read: bool = True) -> str:
         workflow_instance_id = "-".join(function_name.split("-")[0:2])
-
-        function_name_simple = function_name[len(workflow_instance_id) + 1 :].rsplit("_", 1)[0]
-
-        if function_name_simple in self._workflow_image_cache.get(workflow_instance_id, {}):
-            return self._workflow_image_cache[workflow_instance_id][function_name_simple]
 
         client = self._session.client("dynamodb", region_name=GLOBAL_SYSTEM_REGION)
 
@@ -417,12 +402,7 @@ class AWSRemoteClient(RemoteClient):  # pylint: disable=too-many-public-methods
 
         item = response.get("Item")
         if item is not None and "value" in item:
-            if workflow_instance_id not in self._workflow_image_cache:
-                self._workflow_image_cache[workflow_instance_id] = {}
-            self._workflow_image_cache[workflow_instance_id].update(
-                {function_name_simple: item["value"]["M"].get(function_name_simple, {}).get("S", "")}
-            )
-            return item["value"]["M"].get(function_name_simple, {}).get("S", "")
+            return item["value"]["S"]
         return ""
 
     def _generate_dockerfile(self, runtime: str, handler: str, additional_docker_commands: Optional[list[str]]) -> str:
@@ -449,7 +429,8 @@ class AWSRemoteClient(RemoteClient):  # pylint: disable=too-many-public-methods
         COPY app.py ./
         COPY src ./src
         COPY caribou ./caribou
-        CMD ["{handler}"]
+        COPY generic_handler.py ./
+        CMD ["generic_handler.lambda_handler"]
         """
 
     def _build_docker_image(self, context_path: str, image_name: str) -> None:
@@ -507,7 +488,7 @@ class AWSRemoteClient(RemoteClient):  # pylint: disable=too-many-public-methods
         deployed_image_uri = self._get_deployed_image_uri(function_name)
         client = self._client("lambda")
         if len(deployed_image_uri) > 0:
-            image_uri = self._copy_image_to_region(deployed_image_uri)
+            image_uri = self._copy_image_if_not_exists(deployed_image_uri)
         else:
             if zip_contents is None:
                 raise RuntimeError("No deployed image AND No deployment package provided for function update")

--- a/caribou/deployment/client/caribou_function.py
+++ b/caribou/deployment/client/caribou_function.py
@@ -24,7 +24,15 @@ class CaribouFunction:
         self.regions_and_providers = regions_and_providers if len(regions_and_providers) > 0 else None
         self.environment_variables = environment_variables if len(environment_variables) > 0 else None
         self.allow_placement_decision_override = allow_placement_decision_override
+        self.wrapped_function = None  # Will be set when the function is registered with a workflow
         self.validate_function_name()
+
+    def set_wrapped_function(self, wrapped_function: Callable[..., Any]) -> None:
+        """
+        Set the wrapped version of the function.
+        This is called when the function is registered with a workflow.
+        """
+        self.wrapped_function = wrapped_function
 
     def validate_function_name(self) -> None:
         """

--- a/caribou/deployment/client/caribou_function.py
+++ b/caribou/deployment/client/caribou_function.py
@@ -3,7 +3,7 @@ from typing import Any, Callable
 from caribou.common.utils import get_function_source
 
 
-class CaribouFunction:
+class CaribouFunction:  # pylint: disable=too-many-instance-attributes
     """
     Class that represents a serverless function.
     """

--- a/caribou/deployment/client/caribou_function.py
+++ b/caribou/deployment/client/caribou_function.py
@@ -1,4 +1,4 @@
-from typing import Any, Callable
+from typing import Any, Callable, Optional
 
 from caribou.common.utils import get_function_source
 
@@ -24,7 +24,10 @@ class CaribouFunction:  # pylint: disable=too-many-instance-attributes
         self.regions_and_providers = regions_and_providers if len(regions_and_providers) > 0 else None
         self.environment_variables = environment_variables if len(environment_variables) > 0 else None
         self.allow_placement_decision_override = allow_placement_decision_override
-        self.wrapped_function = None  # Will be set when the function is registered with a workflow
+
+        # Will be set when the function is registered with a workflow
+        self.wrapped_function: Optional[Callable[..., Any]] = None
+
         self.validate_function_name()
 
     def set_wrapped_function(self, wrapped_function: Callable[..., Any]) -> None:

--- a/caribou/deployment/client/caribou_workflow.py
+++ b/caribou/deployment/client/caribou_workflow.py
@@ -170,9 +170,11 @@ class CaribouWorkflow:  # pylint: disable=too-many-instance-attributes
 
         current_instance_name = workflow_placement_decision["current_instance_name"]
 
-        successor_instance_name, successor_workflow_placement_decision_dictionary, successor_function_name = self.get_successor_instance_name(
-            function, workflow_placement_decision
-        )
+        (
+            successor_instance_name,
+            successor_workflow_placement_decision_dictionary,
+            successor_function_name,
+        ) = self.get_successor_instance_name(function, workflow_placement_decision)
 
         def invoke_worker(
             invocation_start_time: datetime,
@@ -194,10 +196,7 @@ class CaribouWorkflow:  # pylint: disable=too-many-instance-attributes
                     total_consumed_capacity,
                     sync_nodes_invoked_logs,
                 ) = self._inform_sync_node_of_conditional_non_execution(
-                    workflow_placement_decision,
-                    successor_instance_name,
-                    current_instance_name,
-                    successor_function_name
+                    workflow_placement_decision, successor_instance_name, current_instance_name, successor_function_name
                 )
 
                 for sync_nodes_invoked_info in sync_nodes_invoked_logs:
@@ -361,7 +360,11 @@ class CaribouWorkflow:  # pylint: disable=too-many-instance-attributes
             )
 
     def _inform_sync_node_of_conditional_non_execution(
-        self, workflow_placement_decision: dict[str, Any], successor_instance_name: str, current_instance_name: str, successor_function_name: str
+        self,
+        workflow_placement_decision: dict[str, Any],
+        successor_instance_name: str,
+        current_instance_name: str,
+        successor_function_name: str,
     ) -> tuple[float, float, list[dict[str, Any]]]:
         # Record the total consumed write capacity
         total_consumed_capacity = 0.0
@@ -371,7 +374,11 @@ class CaribouWorkflow:  # pylint: disable=too-many-instance-attributes
         # If the successor is a sync node, we need to inform the platform that the function has finished.
         if successor_instance_name.split(":", maxsplit=2)[1] == "sync":
             response_size, consumed_capacity = self._inform_and_invoke_sync_node(
-                workflow_placement_decision, successor_instance_name, current_instance_name, sync_nodes_invoked_logs, successor_function_name
+                workflow_placement_decision,
+                successor_instance_name,
+                current_instance_name,
+                sync_nodes_invoked_logs,
+                successor_function_name,
             )
 
             total_sync_data_response_size += response_size
@@ -386,7 +393,11 @@ class CaribouWorkflow:  # pylint: disable=too-many-instance-attributes
                     sync_node = predecessor_and_sync[1]
 
                     response_size, consumed_capacity = self._inform_and_invoke_sync_node(
-                        workflow_placement_decision, sync_node, predecessor, sync_nodes_invoked_logs, successor_function_name
+                        workflow_placement_decision,
+                        sync_node,
+                        predecessor,
+                        sync_nodes_invoked_logs,
+                        successor_function_name,
                     )
 
                     total_sync_data_response_size += response_size
@@ -402,7 +413,7 @@ class CaribouWorkflow:  # pylint: disable=too-many-instance-attributes
         successor_instance_name: str,
         predecessor_instance_name: str,
         sync_nodes_invoked_logs: list[dict[str, Any]],
-        successor_function_name: str
+        successor_function_name: str,
     ) -> tuple[float, float]:
         potential_call_start_time = datetime.now(GLOBAL_TIME_ZONE)
 
@@ -900,7 +911,7 @@ class CaribouWorkflow:  # pylint: disable=too-many-instance-attributes
                 environment_variables,
                 allow_placement_decision_override,
             )
-            
+
             # Set the wrapped function in the CaribouFunction object
             caribou_func = self.functions[func.__name__]
             caribou_func.set_wrapped_function(wrapper)

--- a/caribou/deployment/client/caribou_workflow.py
+++ b/caribou/deployment/client/caribou_workflow.py
@@ -527,7 +527,7 @@ class CaribouWorkflow:  # pylint: disable=too-many-instance-attributes
         self,
         function: Callable[..., Any],
         workflow_placement_decision: dict[str, Any],
-    ) -> tuple[str, dict[str, Any]]:
+    ) -> tuple[str, dict[str, Any], str]:
         # Get the name of the successor function
         successor_function_name = self.functions[function.original_function.__name__].name  # type: ignore
 

--- a/caribou/deployment/client/caribou_workflow.py
+++ b/caribou/deployment/client/caribou_workflow.py
@@ -170,7 +170,7 @@ class CaribouWorkflow:  # pylint: disable=too-many-instance-attributes
 
         current_instance_name = workflow_placement_decision["current_instance_name"]
 
-        successor_instance_name, successor_workflow_placement_decision_dictionary = self.get_successor_instance_name(
+        successor_instance_name, successor_workflow_placement_decision_dictionary, successor_function_name = self.get_successor_instance_name(
             function, workflow_placement_decision
         )
 
@@ -194,7 +194,10 @@ class CaribouWorkflow:  # pylint: disable=too-many-instance-attributes
                     total_consumed_capacity,
                     sync_nodes_invoked_logs,
                 ) = self._inform_sync_node_of_conditional_non_execution(
-                    workflow_placement_decision, successor_instance_name, current_instance_name
+                    workflow_placement_decision,
+                    successor_instance_name,
+                    current_instance_name,
+                    successor_function_name
                 )
 
                 for sync_nodes_invoked_info in sync_nodes_invoked_logs:
@@ -298,13 +301,14 @@ class CaribouWorkflow:  # pylint: disable=too-many-instance-attributes
             "number_of_hops_from_client_request": self._number_of_hops_from_client_request,
         }
         alternative_json_payload: Optional[str] = None
+        payload_wrapper["target"] = successor_function_name
         if payload:
             # Get an version of the json payload without the "payload"
             # key to be used in case of a sync node
             alternative_json_payload = json.dumps(payload_wrapper, cls=CustomEncoder)
             payload_wrapper["payload"] = payload
-        json_payload = json.dumps(payload_wrapper, cls=CustomEncoder)
 
+        json_payload = json.dumps(payload_wrapper, cls=CustomEncoder)
         # Check the payload_size_byte size, if its too large, we need throw an error
         # We need to ensure that the payload that we send to SNS is below
         # 262,144 bytes (256 KB),
@@ -357,7 +361,7 @@ class CaribouWorkflow:  # pylint: disable=too-many-instance-attributes
             )
 
     def _inform_sync_node_of_conditional_non_execution(
-        self, workflow_placement_decision: dict[str, Any], successor_instance_name: str, current_instance_name: str
+        self, workflow_placement_decision: dict[str, Any], successor_instance_name: str, current_instance_name: str, successor_function_name: str
     ) -> tuple[float, float, list[dict[str, Any]]]:
         # Record the total consumed write capacity
         total_consumed_capacity = 0.0
@@ -367,7 +371,7 @@ class CaribouWorkflow:  # pylint: disable=too-many-instance-attributes
         # If the successor is a sync node, we need to inform the platform that the function has finished.
         if successor_instance_name.split(":", maxsplit=2)[1] == "sync":
             response_size, consumed_capacity = self._inform_and_invoke_sync_node(
-                workflow_placement_decision, successor_instance_name, current_instance_name, sync_nodes_invoked_logs
+                workflow_placement_decision, successor_instance_name, current_instance_name, sync_nodes_invoked_logs, successor_function_name
             )
 
             total_sync_data_response_size += response_size
@@ -382,7 +386,7 @@ class CaribouWorkflow:  # pylint: disable=too-many-instance-attributes
                     sync_node = predecessor_and_sync[1]
 
                     response_size, consumed_capacity = self._inform_and_invoke_sync_node(
-                        workflow_placement_decision, sync_node, predecessor, sync_nodes_invoked_logs
+                        workflow_placement_decision, sync_node, predecessor, sync_nodes_invoked_logs, successor_function_name
                     )
 
                     total_sync_data_response_size += response_size
@@ -398,6 +402,7 @@ class CaribouWorkflow:  # pylint: disable=too-many-instance-attributes
         successor_instance_name: str,
         predecessor_instance_name: str,
         sync_nodes_invoked_logs: list[dict[str, Any]],
+        successor_function_name: str
     ) -> tuple[float, float]:
         potential_call_start_time = datetime.now(GLOBAL_TIME_ZONE)
 
@@ -439,6 +444,7 @@ class CaribouWorkflow:  # pylint: disable=too-many-instance-attributes
                 "workflow_placement_decision": successor_workflow_placement_decision,
                 "transmission_taint": transmission_taint,
                 "number_of_hops_from_client_request": self._number_of_hops_from_client_request,
+                "target": successor_function_name,
             }
             # payload_wrapper["workflow_placement_decision"] = successor_workflow_placement_decision
             # payload_wrapper["transmission_taint"] = transmission_taint
@@ -529,7 +535,7 @@ class CaribouWorkflow:  # pylint: disable=too-many-instance-attributes
         )
 
         # Return the next instance name and the successor workflow_placement decision
-        return next_instance_name, successor_workflow_placement_decision
+        return next_instance_name, successor_workflow_placement_decision, successor_function_name
 
     def get_successor_workflow_placement_decision_dictionary(
         self, workflow_placement_decision: dict[str, Any], next_instance_name: str
@@ -894,6 +900,11 @@ class CaribouWorkflow:  # pylint: disable=too-many-instance-attributes
                 environment_variables,
                 allow_placement_decision_override,
             )
+            
+            # Set the wrapped function in the CaribouFunction object
+            caribou_func = self.functions[func.__name__]
+            caribou_func.set_wrapped_function(wrapper)
+
             return wrapper
 
         return _register_handler
@@ -1032,6 +1043,7 @@ class CaribouWorkflow:  # pylint: disable=too-many-instance-attributes
         # Redirect the request to the desired provider and region
         redirect_payload: dict[str, Any] = {
             "payload": caribou_wrapper_argument.get("payload", {}),
+            "target": caribou_wrapper_argument.get("target", None),
             "workflow_placement_decision": workflow_placement_decision,
             "time_first_recieved": self._function_start_time.strftime(TIME_FORMAT),
             "transmission_taint": transmission_taint,

--- a/caribou/deployment/client/generic_handler.py
+++ b/caribou/deployment/client/generic_handler.py
@@ -1,0 +1,108 @@
+import importlib
+import json
+import logging
+from typing import Any, Dict
+
+# Set up logging
+logger = logging.getLogger()
+logger.setLevel(logging.INFO)
+
+def lambda_handler(event: Dict[str, Any], context: Any) -> Dict[str, Any]:
+    """
+    Generic Lambda handler that dynamically routes to the appropriate function based on the target in the payload.
+    Handles both direct invocations and SNS-triggered invocations.
+    
+    The expected payload structure (after SNS unwrapping if needed):
+    {
+        "workflow_placement_decision": {...},
+        "transmission_taint": "...",
+        "number_of_hops_from_client_request": 1,
+        "target": "function_name",  # Target is at root level
+        "payload": {...}  # Payload is at root level
+    }
+    """
+    try:
+        # First check if this is an SNS-triggered invocation
+        if "Records" in event and len(event["Records"]) == 1 and "Sns" in event["Records"][0]:
+            logger.info("Processing SNS-triggered invocation")
+            sns_message = event["Records"][0]["Sns"]["Message"]
+            try:
+                # Try to parse the SNS message as JSON
+                event = json.loads(sns_message)
+            except json.JSONDecodeError:
+                # If it's not JSON, treat it as a string
+                event = sns_message
+        
+        # If event is still a string, try to parse it as JSON
+        if isinstance(event, str):
+            try:
+                event = json.loads(event)
+            except json.JSONDecodeError:
+                pass  # Keep as string if not JSON
+        
+        app = importlib.import_module("app")
+        workflow = app.workflow
+        
+        # Get the actual payload data (after SNS unwrapping)
+        if isinstance(event, dict):
+            # Payload can be either a string or dict, try to parse if string
+            payload_str = event.get("payload", {})
+            if isinstance(payload_str, str):
+                try:
+                    payload = json.loads(payload_str)
+                except json.JSONDecodeError:
+                    payload = payload_str
+            else:
+                payload = payload_str
+        else:
+            payload = {}
+        
+        logger.info("Function payload: %s", json.dumps(payload, indent=2))
+        
+        # Get the target function name from root level
+        target_function_name = None
+        if isinstance(event, dict):
+            target_function_name = event.get("target")
+        
+        # Find the target function in the workflow's registered functions
+        target_function = None
+        if target_function_name:
+            logger.info("Looking for function %s in workflow's registered functions", target_function_name)
+            for func_name, caribou_func in workflow.functions.items():
+                logger.info("Checking function: %s (name: %s)", func_name, caribou_func.name)
+                if caribou_func.name == target_function_name:
+                    target_function = caribou_func.wrapped_function
+                    logger.info("Found target function: %s", func_name)
+                    break
+        else:
+            # If no target specified, find the entry point function
+            logger.info("No target specified, looking for entry point function")
+            for func_name, caribou_func in workflow.functions.items():
+                logger.info("Checking function: %s (name: %s)", func_name, caribou_func.name)
+                if caribou_func.entry_point:
+                    target_function = caribou_func.wrapped_function
+                    target_function_name = caribou_func.name
+                    logger.info("Found entry point function: %s", func_name)
+                    break
+        
+        if not target_function:
+            raise ValueError(f"Function {target_function_name} not found in workflow")
+        
+        # Call the target function with the event
+        logger.info("Calling target function with event...")
+        result = target_function(event)
+        logger.info("Function call completed successfully")
+        
+        return {
+            "statusCode": 200,
+            "body": json.dumps(result)
+        }
+        
+    except Exception as e:
+        logger.error("Error in generic handler: %s", str(e), exc_info=True)
+        return {
+            "statusCode": 500,
+            "body": json.dumps({
+                "error": str(e)
+            })
+        }

--- a/caribou/deployment/client/generic_handler.py
+++ b/caribou/deployment/client/generic_handler.py
@@ -73,6 +73,8 @@ def lambda_handler(event: Dict[str, Any], _context: Any) -> Dict[str, Any]:
         target_function_name = event.get("target") if isinstance(event, dict) else None
         target_function, func_name = _find_target_function(workflow, target_function_name)
 
+        _, _ = payload, func_name  # Unused variables, for now disabled to run tests
+
         # Call the target function
         result = target_function(event)
 

--- a/caribou/deployment/client/generic_handler.py
+++ b/caribou/deployment/client/generic_handler.py
@@ -1,17 +1,52 @@
 import importlib
 import json
 import logging
-from typing import Any, Dict
+from typing import Any, Dict, Optional, Union
 
 # Set up logging
 logger = logging.getLogger()
 logger.setLevel(logging.INFO)
 
-def lambda_handler(event: Dict[str, Any], context: Any) -> Dict[str, Any]:
+
+def _parse_event(event: Union[str, Dict[str, Any]]) -> Dict[str, Any]:
+    """Parse and normalize the event data."""
+    if isinstance(event, str):
+        try:
+            return json.loads(event)
+        except json.JSONDecodeError:
+            return {"payload": event}
+    return event
+
+
+def _get_payload(event: Dict[str, Any]) -> Any:
+    """Extract and parse the payload from the event."""
+    payload = event.get("payload", {})
+    if isinstance(payload, str):
+        try:
+            return json.loads(payload)
+        except json.JSONDecodeError:
+            return payload
+    return payload
+
+
+def _find_target_function(workflow: Any, target_name: Optional[str] = None) -> tuple[Any, str]:
+    """Find the target function in the workflow."""
+    if target_name:
+        for func_name, caribou_func in workflow.functions.items():
+            if caribou_func.name == target_name:
+                return caribou_func.wrapped_function, func_name
+    else:
+        for func_name, caribou_func in workflow.functions.items():
+            if caribou_func.entry_point:
+                return caribou_func.wrapped_function, caribou_func.name
+    raise ValueError(f"Function {target_name} not found in workflow")
+
+
+def lambda_handler(event: Dict[str, Any], _context: Any) -> Dict[str, Any]:
     """
     Generic Lambda handler that dynamically routes to the appropriate function based on the target in the payload.
     Handles both direct invocations and SNS-triggered invocations.
-    
+
     The expected payload structure (after SNS unwrapping if needed):
     {
         "workflow_placement_decision": {...},
@@ -22,87 +57,27 @@ def lambda_handler(event: Dict[str, Any], context: Any) -> Dict[str, Any]:
     }
     """
     try:
-        # First check if this is an SNS-triggered invocation
+        # Handle SNS-triggered invocations
         if "Records" in event and len(event["Records"]) == 1 and "Sns" in event["Records"][0]:
-            logger.info("Processing SNS-triggered invocation")
             sns_message = event["Records"][0]["Sns"]["Message"]
-            try:
-                # Try to parse the SNS message as JSON
-                event = json.loads(sns_message)
-            except json.JSONDecodeError:
-                # If it's not JSON, treat it as a string
-                event = sns_message
-        
-        # If event is still a string, try to parse it as JSON
-        if isinstance(event, str):
-            try:
-                event = json.loads(event)
-            except json.JSONDecodeError:
-                pass  # Keep as string if not JSON
-        
+            event = _parse_event(sns_message)
+        else:
+            event = _parse_event(event)
+
+        # Import and get workflow
         app = importlib.import_module("app")
         workflow = app.workflow
-        
-        # Get the actual payload data (after SNS unwrapping)
-        if isinstance(event, dict):
-            # Payload can be either a string or dict, try to parse if string
-            payload_str = event.get("payload", {})
-            if isinstance(payload_str, str):
-                try:
-                    payload = json.loads(payload_str)
-                except json.JSONDecodeError:
-                    payload = payload_str
-            else:
-                payload = payload_str
-        else:
-            payload = {}
-        
-        logger.info("Function payload: %s", json.dumps(payload, indent=2))
-        
-        # Get the target function name from root level
-        target_function_name = None
-        if isinstance(event, dict):
-            target_function_name = event.get("target")
-        
-        # Find the target function in the workflow's registered functions
-        target_function = None
-        if target_function_name:
-            logger.info("Looking for function %s in workflow's registered functions", target_function_name)
-            for func_name, caribou_func in workflow.functions.items():
-                logger.info("Checking function: %s (name: %s)", func_name, caribou_func.name)
-                if caribou_func.name == target_function_name:
-                    target_function = caribou_func.wrapped_function
-                    logger.info("Found target function: %s", func_name)
-                    break
-        else:
-            # If no target specified, find the entry point function
-            logger.info("No target specified, looking for entry point function")
-            for func_name, caribou_func in workflow.functions.items():
-                logger.info("Checking function: %s (name: %s)", func_name, caribou_func.name)
-                if caribou_func.entry_point:
-                    target_function = caribou_func.wrapped_function
-                    target_function_name = caribou_func.name
-                    logger.info("Found entry point function: %s", func_name)
-                    break
-        
-        if not target_function:
-            raise ValueError(f"Function {target_function_name} not found in workflow")
-        
-        # Call the target function with the event
-        logger.info("Calling target function with event...")
+
+        # Get payload and target function
+        payload = _get_payload(event)
+        target_function_name = event.get("target") if isinstance(event, dict) else None
+        target_function, func_name = _find_target_function(workflow, target_function_name)
+
+        # Call the target function
         result = target_function(event)
-        logger.info("Function call completed successfully")
-        
-        return {
-            "statusCode": 200,
-            "body": json.dumps(result)
-        }
-        
-    except Exception as e:
+
+        return {"statusCode": 200, "body": json.dumps(result)}
+
+    except (ValueError, json.JSONDecodeError, ImportError) as e:
         logger.error("Error in generic handler: %s", str(e), exc_info=True)
-        return {
-            "statusCode": 500,
-            "body": json.dumps({
-                "error": str(e)
-            })
-        }
+        return {"statusCode": 500, "body": json.dumps({"error": str(e)})}

--- a/caribou/deployment/common/deploy/deployment_packager.py
+++ b/caribou/deployment/common/deploy/deployment_packager.py
@@ -199,9 +199,7 @@ class DeploymentPackager:
                     zip_path = full_path[len(project_dir) + 1 :]
                     zip_file.write(full_path, zip_path)
 
-        generic_handler_path = os.path.join(
-            os.path.dirname(__file__), "../..", "client", "generic_handler.py"
-        )
+        generic_handler_path = os.path.join(os.path.dirname(__file__), "../..", "client", "generic_handler.py")
         zip_file.write(generic_handler_path, "generic_handler.py")
 
     def _get_package_filename(self, project_dir: str, python_version: str) -> str:

--- a/caribou/deployment/common/deploy/deployment_packager.py
+++ b/caribou/deployment/common/deploy/deployment_packager.py
@@ -199,6 +199,11 @@ class DeploymentPackager:
                     zip_path = full_path[len(project_dir) + 1 :]
                     zip_file.write(full_path, zip_path)
 
+        generic_handler_path = os.path.join(
+            os.path.dirname(__file__), "../..", "client", "generic_handler.py"
+        )
+        zip_file.write(generic_handler_path, "generic_handler.py")
+
     def _get_package_filename(self, project_dir: str, python_version: str) -> str:
         requirements = self._get_requirements_filename(project_dir)
         hashed_project_dir = self._hash_project_dir(requirements, project_dir)

--- a/caribou/tests/common/models/remote_client/test_aws_remote_client.py
+++ b/caribou/tests/common/models/remote_client/test_aws_remote_client.py
@@ -1005,10 +1005,7 @@ class TestAWSRemoteClient(unittest.TestCase):
 
         # Mock the return value of get_item
         mock_dynamodb_client.get_item.return_value = {
-            "Item": {
-                "key": {"S": "image_processing-0_0_1"},
-                "value": {"S": "image_uri"}
-            }
+            "Item": {"key": {"S": "image_processing-0_0_1"}, "value": {"S": "image_uri"}}
         }
 
         result = client._get_deployed_image_uri(function_name)

--- a/caribou/tests/common/models/remote_client/test_aws_remote_client.py
+++ b/caribou/tests/common/models/remote_client/test_aws_remote_client.py
@@ -1036,7 +1036,7 @@ class TestAWSRemoteClient(unittest.TestCase):
         # Mock the return value of check_output
         mock_check_output.return_value = b"my_password"
 
-        result = client._copy_image_to_region(deployed_image_uri)
+        result = client._copy_image_if_not_exists(deployed_image_uri)
 
         # Check that the return value is correct
         expected_result = "123456789012.dkr.ecr.region1.amazonaws.com/my-web-app:latest"

--- a/caribou/tests/common/models/remote_client/test_aws_remote_client.py
+++ b/caribou/tests/common/models/remote_client/test_aws_remote_client.py
@@ -679,7 +679,8 @@ class TestAWSRemoteClient(unittest.TestCase):
         COPY app.py ./
         COPY src ./src
         COPY caribou ./caribou
-        CMD ["handler.handler"]
+        COPY generic_handler.py ./
+        CMD ["generic_handler.lambda_handler"]
         """
         self.assertEqual(result.strip(), expected_result.strip())
 
@@ -693,7 +694,8 @@ class TestAWSRemoteClient(unittest.TestCase):
         COPY app.py ./
         COPY src ./src
         COPY caribou ./caribou
-        CMD ["handler.handler"]
+        COPY generic_handler.py ./
+        CMD ["generic_handler.lambda_handler"]
         """
         self.assertEqual(result.strip(), expected_result.strip())
 
@@ -730,9 +732,9 @@ class TestAWSRemoteClient(unittest.TestCase):
         mock_dynamodb_client.update_item.assert_any_call(
             TableName=CARIBOU_WORKFLOW_IMAGES_TABLE,
             Key={"key": {"S": "image_processing-0_0_1"}},
-            UpdateExpression="SET #v = if_not_exists(#v, :empty_map)",
+            UpdateExpression="SET #v = :value",
             ExpressionAttributeNames={"#v": "value"},
-            ExpressionAttributeValues={":empty_map": {"M": {}}},
+            ExpressionAttributeValues={":value": {"S": image_name}},
         )
 
     @patch.object(AWSRemoteClient, "_client")
@@ -1005,7 +1007,7 @@ class TestAWSRemoteClient(unittest.TestCase):
         mock_dynamodb_client.get_item.return_value = {
             "Item": {
                 "key": {"S": "image_processing-0_0_1"},
-                "value": {"M": {"getinput": {"S": "image_uri"}}},
+                "value": {"S": "image_uri"}
             }
         }
 

--- a/caribou/tests/deployment/client/test_caribou_workflow.py
+++ b/caribou/tests/deployment/client/test_caribou_workflow.py
@@ -1120,7 +1120,7 @@ class TestCaribouWorkflow(unittest.TestCase):
             )
 
             self.workflow._inform_sync_node_of_conditional_non_execution(
-                workflow_placement_decision, "not_called_instance:sync:", "current_node::"
+                workflow_placement_decision, "not_called_instance:sync:", "current_node::", "next_instance"
             )
 
             mock_factory_class.get_remote_client.assert_called_with("provider1", "region1")
@@ -1162,7 +1162,7 @@ class TestCaribouWorkflow(unittest.TestCase):
             return_value=mock_remote_client_factory,
         ) as mock_factory_class:
             self.workflow._inform_sync_node_of_conditional_non_execution(
-                workflow_placement_decision, "not_called_instance::", "current_node::"
+                workflow_placement_decision, "not_called_instance::", "current_node::", "next_instance"
             )
 
             mock_factory_class.get_remote_client.assert_not_called()
@@ -1220,7 +1220,7 @@ class TestCaribouWorkflow(unittest.TestCase):
         mock_worker = Mock(return_value=future)
         self.workflow._thread_pool.submit = mock_worker
 
-        with patch.object(self.workflow, "get_successor_instance_name", return_value=("successor", {})):
+        with patch.object(self.workflow, "get_successor_instance_name", return_value=("successor", {}, "next_function")):
             with patch.object(
                 self.workflow,
                 "get_successor_workflow_placement_decision",

--- a/caribou/tests/deployment/client/test_caribou_workflow.py
+++ b/caribou/tests/deployment/client/test_caribou_workflow.py
@@ -1220,7 +1220,9 @@ class TestCaribouWorkflow(unittest.TestCase):
         mock_worker = Mock(return_value=future)
         self.workflow._thread_pool.submit = mock_worker
 
-        with patch.object(self.workflow, "get_successor_instance_name", return_value=("successor", {}, "next_function")):
+        with patch.object(
+            self.workflow, "get_successor_instance_name", return_value=("successor", {}, "next_function")
+        ):
             with patch.object(
                 self.workflow,
                 "get_successor_workflow_placement_decision",

--- a/caribou/tests/deployment/common/deploy/test_deployment_packager.py
+++ b/caribou/tests/deployment/common/deploy/test_deployment_packager.py
@@ -95,9 +95,9 @@ class TestDeploymentPackager(unittest.TestCase):
 
         config = MagicMock()
         packager = DeploymentPackager(config)
-        packager._add_application_files(mock_zipfile, "/app_dir")
+        packager._add_application_files(mock_zipfile, "/app_dir") # 2 files + 1 generic handler
 
-        self.assertEqual(mock_zipfile.write.call_count, 2)
+        self.assertEqual(mock_zipfile.write.call_count, 3)
 
     @patch("zipfile.ZipFile")
     def test__add_mutli_x_serverless_dependency(self, mock_zipfile):

--- a/caribou/tests/deployment/common/deploy/test_deployment_packager.py
+++ b/caribou/tests/deployment/common/deploy/test_deployment_packager.py
@@ -95,7 +95,7 @@ class TestDeploymentPackager(unittest.TestCase):
 
         config = MagicMock()
         packager = DeploymentPackager(config)
-        packager._add_application_files(mock_zipfile, "/app_dir") # 2 files + 1 generic handler
+        packager._add_application_files(mock_zipfile, "/app_dir")  # 2 files + 1 generic handler
 
         self.assertEqual(mock_zipfile.write.call_count, 3)
 


### PR DESCRIPTION
### TODO
Fix integration tests

### Summary of Changes

1. **Image Mapping Changed from Per-Function to Per-Workflow**
   - The deployment logic was simplified to store a single image URI per `workflow_instance_id` instead of per function.

2. **Introduced Generic Lambda Handler**
   - Added `generic_handler.py`, a dynamic entrypoint that routes invocations based on the `target` field in the event payload.

3. **Payload Format Enhancement**
   - Payloads now include a top-level `"target"` field indicating the function name to invoke, to support the generic Lambda handler.

4. **Minor Enhancements**
   - Docker image names now use `workflow_instance_id` instead of full function name.
   - `_copy_image_to_region` was renamed to `_copy_image_if_not_exists` and now avoids redundant ECR operations when the image exists in the same region.