### PR TITLE
Cloudping has moved to an API endpoint based system

### DIFF
--- a/caribou/data_collector/utils/constants.py
+++ b/caribou/data_collector/utils/constants.py
@@ -1,2 +1,2 @@
 AMAZON_REGION_URL = "https://docs.aws.amazon.com/global-infrastructure/latest/regions/aws-regions.html#available-regions"  # pylint: disable=line-too-long
-CLOUD_PING = "https://www.cloudping.co/grid/"
+CLOUD_PING = "https://www.cloudping.co/api/latencies"


### PR DESCRIPTION
- Changed CLOUD_PING URI to the correct URI "https://www.cloudping.co/api/latencies"
- Changed system from web scraping and parsing table into a GET request to the API
- Deleting the parse_table method
- Removed beautifulsoup import, not used anymore
- Rewritten test to reflect the changes